### PR TITLE
Allow handling features with null geometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgis-pbf-parser",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A library for parsing the arcgis pbf format into geojson",
   "main": "dist/arcgis-pbf.cjs",
   "module": "dist/arcgis-pbf.mjs",

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,7 @@ export default function decode(featureCollectionBuffer) {
       type: 'Feature',
       id: getFeatureId(fields, f.attributes, objectIdField),
       properties: collectAttributes(fields, f.attributes),
-      geometry: geometryParser(f, transform)
+      geometry: f.geometry && geometryParser(f, transform)
     })
   }
 


### PR DESCRIPTION
Updated to pass `geometry: null` as-is, instead of passing the value to `geometryParser` which will result the `Cannot read properties of undefined (reading 'length') error`